### PR TITLE
Add GH actions to test build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag power-systems-data-api-demonstrator:$(date +%s)


### PR DESCRIPTION
## Issue

We currently do not have any CI/CD

## Description

* Propose to use GitHub actions to do basic CI/CD (build + test) - here only build is tested