### PR TITLE
Updated route path to point to /api instead of /gridNode

### DIFF
--- a/power_systems_data_api_demonstrator/src/api/docs/views.py
+++ b/power_systems_data_api_demonstrator/src/api/docs/views.py
@@ -13,7 +13,7 @@ from power_systems_data_api_demonstrator.static.docs.utils import get_app_title
 router = APIRouter()
 
 
-@router.get("/")
+@router.get("/", include_in_schema=False)
 async def redirect() -> RedirectResponse:
     return RedirectResponse(url="/docs")
 

--- a/power_systems_data_api_demonstrator/src/api/router.py
+++ b/power_systems_data_api_demonstrator/src/api/router.py
@@ -5,6 +5,6 @@ from fastapi.routing import APIRouter
 from power_systems_data_api_demonstrator.src.api import docs, grid_node, monitoring
 
 api_router = APIRouter()
-api_router.include_router(grid_node.router, prefix="/gridNode", tags=["gridNode"])
-api_router.include_router(monitoring.router, tags=["monitoring"])
+api_router.include_router(grid_node.router, prefix="/api", tags=["gridNode"])
+api_router.include_router(monitoring.router, prefix="/monitoring", tags=["monitoring"])
 api_router.include_router(docs.router)

--- a/power_systems_data_api_demonstrator/tests/test_routes.py
+++ b/power_systems_data_api_demonstrator/tests/test_routes.py
@@ -13,7 +13,7 @@ async def test_health(fastapi_client: AsyncClient) -> None:
     :param client: clien for the app.
     """
     response = await fastapi_client.get(
-        url="/health",
+        url="/monitoring/health",
     )
     assert response.is_success
 
@@ -26,7 +26,7 @@ async def test_grid_nodes(fastapi_client: AsyncClient) -> None:
     :param client: clien for the app.
     """
     response = await fastapi_client.get(
-        url="/gridNode/list",
+        url="/api/list",
     )
     assert response.is_success
     assert response.json()
@@ -35,7 +35,7 @@ async def test_grid_nodes(fastapi_client: AsyncClient) -> None:
 @pytest.mark.parametrize("grid_node_id", [("US-WECC-CISO"), ("UK-GB"), ("ES")])
 async def test_generation(fastapi_client: AsyncClient, grid_node_id: str) -> None:
     response = await fastapi_client.get(
-        url=f"/gridNode/generation/{grid_node_id}",
+        url=f"/api/generation/{grid_node_id}",
     )
     assert response.is_success
     assert response.json()
@@ -44,6 +44,6 @@ async def test_generation(fastapi_client: AsyncClient, grid_node_id: str) -> Non
 @pytest.mark.parametrize("grid_node_id", [("US-WECC-CISO"), ("UK-GB"), ("ES")])
 async def test_demand(fastapi_client: AsyncClient, grid_node_id: str) -> None:
     response = await fastapi_client.get(
-        url=f"/gridNode/demand/{grid_node_id}",
+        url=f"/api/demand/{grid_node_id}",
     )
     assert response.is_success


### PR DESCRIPTION
## Issue

The endpoint still included the term gridNode, which we had agreed was misleading.

## Description

This replaces /gridNode with /api to generalize the routes. It also hides the redirect endpoint that redirects to /docs.

### Preview

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/7773786/232794150-0c7bbf73-da41-4cfb-a89b-3e4f0d776ff0.png">

