### PR TITLE
renamed grid node type to grid topology level

### DIFF
--- a/power_systems_data_api_demonstrator/src/api/grid_node/schema.py
+++ b/power_systems_data_api_demonstrator/src/api/grid_node/schema.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from power_systems_data_api_demonstrator.src.lib.db.models.generation import FuelTypes
 
 
-class GridNodeType(str, Enum):
+class GridTopologyLevel(str, Enum):
     GENERATION_UNIT = "GENERATION_UNIT"
     POWER_PLANT = "POWER_PLANT"
     SUBSTATION = "SUBSTATION"
@@ -25,7 +25,7 @@ class GridNodeModelDTO(BaseModel):
 
     id: str
     name: str
-    type: GridNodeType
+    type: GridTopologyLevel
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Issue

https://github.com/carbon-data-specification/Power-Systems-Data-API-Demonstrator/issues/58

## Description

This is a simple rename of GridNodeType to GridTopologyLevel.

### Preview

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/7773786/232795348-d7ae5ba8-b1fa-4fcd-8c4a-22879d8dbfc6.png">

