### PR TITLE
Precursor to removing db.sqlite from github

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 services:
-  api:
+  api: &api
     build:
       context: .
     image: power_systems_data_api_demonstrator:${POWER_SYSTEMS_DATA_API_DEMONSTRATOR_VERSION:-latest}
@@ -16,3 +16,6 @@ services:
     volumes:
       - ./power_systems_data_api_demonstrator:/power_systems_data_api_demonstrator
       - ./:/app
+  seed:
+    <<: *api
+    command: python power_systems_data_api_demonstrator/seed/seed.py

--- a/server_start.sh
+++ b/server_start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python power_systems_data_api_demonstrator/seed/seed.py && uvicorn power_systems_data_api_demonstrator.src.application:get_app --host 0.0.0.0 --port 10000


### PR DESCRIPTION
## Issue

This is hopefully a precursor to removing sqlite from github. With the dynamically changing data with new endpoints, we end up with frequent merge conflicts on the sqlite file.

## Description

The server will use the startup script that first seeds a db.sqlite file and then starts uvicorn up. Local developers will run the `docker-compose run --rm seed` command whenever they want to update or create the db.sqlite file.

### Preview
